### PR TITLE
Add ability to copy link to selected text

### DIFF
--- a/chrome/content/clipboard.js
+++ b/chrome/content/clipboard.js
@@ -1,3 +1,9 @@
 function copySelectedTextURL() {
- Cc["@mozilla.org/widget/clipboardhelper;1"].getService(Ci.nsIClipboardHelper).copyString(gBrowser.currentURI.spec + "#:~:text=" + gBrowser.contentWindow.getSelection().toString());
+ var currentURL = gBrowser.contentWindow.location.href;
+ var hashLoc = currentURL.indexOf("#");
+ if (hashLoc > 0) {
+  Cc["@mozilla.org/widget/clipboardhelper;1"].getService(Ci.nsIClipboardHelper).copyString(currentURL.substring(0, hashLoc) + "#:~:text=" + gBrowser.contentWindow.getSelection().toString());
+ } else {
+  Cc["@mozilla.org/widget/clipboardhelper;1"].getService(Ci.nsIClipboardHelper).copyString(currentURL + "#:~:text=" + gBrowser.contentWindow.getSelection().toString());
+ }
 }

--- a/chrome/content/clipboard.js
+++ b/chrome/content/clipboard.js
@@ -1,0 +1,3 @@
+function copySelectedTextURL() {
+ Cc["@mozilla.org/widget/clipboardhelper;1"].getService(Ci.nsIClipboardHelper).copyString(gBrowser.currentURI.spec + "#:~:text=" + gBrowser.contentWindow.getSelection().toString());
+}

--- a/chrome/content/overlay.xul
+++ b/chrome/content/overlay.xul
@@ -1,4 +1,9 @@
 <?xml version="1.0"?>
+<!DOCTYPE overlay SYSTEM "chrome://sttf/locale/overlay.dtd">
 <overlay id="sttfOverlay" xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
  <script src="chrome://sttf/content/detector.js" />
+ <script src="chrome://sttf/content/clipboard.js" />
+ <popup id="contentAreaContextMenu">
+  <menuitem id="context-sttf" oncommand="copySelectedTextURL();" label="&sttf.menuitem.label;" insertafter="context-copy" />
+ </popup>
 </overlay>

--- a/chrome/locale/en-US/overlay.dtd
+++ b/chrome/locale/en-US/overlay.dtd
@@ -1,0 +1,1 @@
+<!ENTITY sttf.menuitem.label "Copy Link to Selected Text">


### PR DESCRIPTION
This addition should make this add-on on par with the Link to Text Fragment extension in Chrome.